### PR TITLE
extend to make it work 3 ways: (not everyone has hosts on http://host:5000)

### DIFF
--- a/make_addr_list.sh
+++ b/make_addr_list.sh
@@ -1,16 +1,40 @@
 #!/bin/bash
 
 # Take hosts file and convert to addr_list preference line
-# Usage: ./make_addr_list.sh [url] 
+# Usage: ./make_addr_list.sh [url|file] default: stdin
+#
+# eg
+# ./make_addr_list.sh FILE                       # parse file
+# ./make_addr_list.sh URL                        # pull data from URL
+# grep acq /etc/hosts | ./make_addr_list.sh      # load filtered data from stdin
 
-URL=${1:-"http://naboo:5000/hosts"}
+# at D-TACQ, the multimon web tool provides a hosts file for all live UUT's:
+# ./make_addr_list.sh http://naboo:5000/hosts
 
-ips=$(curl -s "$URL" \
-    | grep -v '^#' \
+
+fetch_hosts() {
+	case $1 in
+	http*)
+		curl -s $1;;
+	*)
+		if [ -f $1 ]; then
+			cat $1
+		else
+			echo error $1 not found
+		fi;;
+	esac	
+}
+
+ips=$(fetch_hosts $1 \
+    | grep -v '^#' | grep -v 127.0.0.1 | grep -v :: | grep -v ^$ \
     | awk '{print $1}' \
     | tr '\n' ' ' \
-    | sed 's/ $//')
+    | sed 's/ $//' )
 
-echo "org.phoebus.pv/default=ca" > "workspace.prefs"
-echo "org.phoebus.pv.ca/addr_list=$ips" >> "workspace.prefs"
-echo "org.phoebus.pv.sssca/auto_addr_list=true" >> "workspace.prefs"
+cat - >workspace.prefs <<EOF
+org.phoebus.pv/default=ca
+org.phoebus.pv.ca/addr_list=$ips
+org.phoebus.pv.ca/auto_addr_list=true
+EOF
+
+


### PR DESCRIPTION
Usage: ./make_addr_list.sh [url|file] default: stdin

 eg
 ./make_addr_list.sh FILE                       # parse file
 ./make_addr_list.sh URL                        # pull data from URL
 grep acq /etc/hosts | ./make_addr_list.sh      # load filtered data from stdin

 On branch master
	modified:   make_addr_list.sh