### PR TITLE
ensure xrm tabs always show the $UUT even when launched from 3rd part…

### DIFF
--- a/src/opi/xrm/fmt_rx.bob
+++ b/src/opi/xrm/fmt_rx.bob
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--Saved on 2026-04-01 22:57:20 by pgm-->
 <display version="2.0.0">
-  <name>FMT RX $(MUUT)</name>
+  <name>FMT RX $(UUT)</name>
   <width>750</width>
   <height>740</height>
   <widget type="group" version="3.0.0">

--- a/src/opi/xrm/fmt_sim.bob
+++ b/src/opi/xrm/fmt_sim.bob
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--Saved on 2026-04-13 19:17:25 by pgm-->
 <display version="2.0.0">
-  <name>FMT SIM $(MUUT)</name>
+  <name>FMT SIM $(UUT)</name>
   <width>750</width>
   <height>740</height>
   <widget type="group" version="3.0.0">

--- a/src/opi/xrm/inst.bob
+++ b/src/opi/xrm/inst.bob
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--Saved on 2026-04-12 19:12:25 by pgm-->
 <display version="2.0.0">
-  <name>INST $(MUUT):$(CH)</name>
+  <name>INST $(UUT):$(CH)</name>
   <width>750</width>
   <height>740</height>
   <widget type="group" version="3.0.0">

--- a/src/opi/xrm/pm.bob
+++ b/src/opi/xrm/pm.bob
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <display version="2.0.0">
-  <name>PM $(MUUT)</name>
+  <name>PM $(UUT)</name>
   <width>750</width>
   <height>740</height>
   <widget type="group" version="3.0.0">

--- a/src/opi/xrm/soe_ht.bob
+++ b/src/opi/xrm/soe_ht.bob
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--Saved on 2026-04-09 16:35:22 by pgm-->
 <display version="2.0.0">
-  <name>SOE HT $(MUUT)</name>
+  <name>SOE HT $(UUT)</name>
   <width>750</width>
   <height>740</height>
   <widget type="group" version="3.0.0">

--- a/src/opi/xrm/soe_lut.bob
+++ b/src/opi/xrm/soe_lut.bob
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--Saved on 2026-04-13 11:46:34 by pgm-->
 <display version="2.0.0">
-  <name>SOE_LUT $(MUUT)</name>
+  <name>SOE_LUT $(UUT)</name>
   <width>750</width>
   <height>740</height>
   <widget type="group" version="3.0.0">


### PR DESCRIPTION
…y that lacks $MUUT

=> $MUUT is redundant at this level and not required.

Change created thusly:
sed -ie 's/MUUT/UUT/' src/opi/xrm/*

 On branch master
	modified:   src/opi/xrm/fmt_rx.bob
	modified:   src/opi/xrm/fmt_sim.bob
	modified:   src/opi/xrm/inst.bob
	modified:   src/opi/xrm/pm.bob
	modified:   src/opi/xrm/soe_ht.bob
	modified:   src/opi/xrm/soe_lut.bob